### PR TITLE
chore: add compiler overrides for kotlin-compiler-embeddable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ buildscript {
         resolutionStrategy {
             eachDependency {
                 if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-compiler-embeddable") {
-                    useTarget("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.0")
+                    useTarget("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.10")
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,14 @@
+buildscript {
+    configurations.all {
+        resolutionStrategy {
+            eachDependency {
+                if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-compiler-embeddable") {
+                    useTarget("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.0")
+                }
+            }
+        }
+    }
+}
 plugins {
     id("org.openrewrite.build.root") version("latest.release")
     id("org.openrewrite.build.java-base") version("latest.release")

--- a/rewrite-kotlin/build.gradle.kts
+++ b/rewrite-kotlin/build.gradle.kts
@@ -2,10 +2,10 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("org.openrewrite.build.language-library")
-    kotlin("jvm") version "2.2.0"
+    kotlin("jvm") version "2.2.10"
 }
 
-val kotlinVersion = "2.2.0"
+val kotlinVersion = "2.2.10"
 
 dependencies {
     compileOnly(project(":rewrite-core"))

--- a/tools/language-parser-builder/build.gradle.kts
+++ b/tools/language-parser-builder/build.gradle.kts
@@ -1,3 +1,14 @@
+buildscript {
+    configurations.all {
+        resolutionStrategy {
+            eachDependency {
+                if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-compiler-embeddable") {
+                    useTarget("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.0")
+                }
+            }
+        }
+    }
+}
 plugins {
     id("org.openrewrite.build.language-library") version("latest.release")
 }

--- a/tools/language-parser-builder/build.gradle.kts
+++ b/tools/language-parser-builder/build.gradle.kts
@@ -3,7 +3,7 @@ buildscript {
         resolutionStrategy {
             eachDependency {
                 if (requested.group == "org.jetbrains.kotlin" && requested.name == "kotlin-compiler-embeddable") {
-                    useTarget("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.0")
+                    useTarget("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.10")
                 }
             }
         }


### PR DESCRIPTION
Hi,

 Would it be possible to consider adding temporary overrides for `kotlin-compiler-embeddable` to make the build pipeline pass until kotlin2 support is released?

Best Regards, 
 Vladimir.